### PR TITLE
Fixed links to extras in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ lualine.setup {
 
 ## :fireworks: Integration
 
-- [Kitty](https://github.com/kovidgoyal/kitty) users copy [this](extra/kitty-theme.conf) into their `kitty.conf`.
-- `Xresources` is available [here](extra/xresources).
-- [Foot](https://codeberg.org/dnkl/foot) terminal users can use [this](extra/foot-terminal).
+- [Kitty](https://github.com/kovidgoyal/kitty) users copy [this](extra/citruszest_kitty.conf) into their `kitty.conf`.
+- `Xresources` is available [here](extra/citruszest_xresources).
+- [Foot](https://codeberg.org/dnkl/foot) terminal users can use [this](extra/citruszest_foot).
 - [iterm2](https://iterm2.com/) user can use [this](extra/citruszest.itermcolors).
 - [Alacritty](https://alacritty.org/) user can use [this](extra/citruszest_alacritty.toml).
 


### PR DESCRIPTION
There were a couple broken links in the README for the extra's:
- Kitty
- Foot
- xresources

This PR fixes these links