### PR TITLE
feat: syntax highlighting in diffview

### DIFF
--- a/lua/citruszest/highlights/init.lua
+++ b/lua/citruszest/highlights/init.lua
@@ -13,10 +13,12 @@ end
 ---@param a number between 0 and 1
 ---@return string
 local add_alpha = function(hex, bg, a)
-    local r1, g1, b1 = hex:sub(2,3), hex:sub(4,5), hex:sub(6,7)
-    local r2, g2, b2 = bg:sub(2,3), bg:sub(4,5), bg:sub(6,7)
-    return "#"..string.format("%02x%02x%02x",
-        blend(r1, r2, a), blend(g1, g2, a), blend(b1, b2, a))
+  if not bg:match("^#%x%x%x%x%x%x$") then
+      bg = "#121212"
+  end
+  local r1, g1, b1 = hex:sub(2,3), hex:sub(4,5), hex:sub(6,7)
+  local r2, g2, b2 = bg:sub(2,3), bg:sub(4,5), bg:sub(6,7)
+  return "#" .. string.format("%02x%02x%02x", blend(r1, r2, a), blend(g1, g2, a), blend(b1, b2, a))
 end
 
 ---@param C table

--- a/lua/citruszest/highlights/init.lua
+++ b/lua/citruszest/highlights/init.lua
@@ -1,5 +1,24 @@
 local M = {}
 
+---@param c string r g b of highlight
+---@param bg string r g b of background
+---@param a number between 0 and 1
+---@return number
+local blend = function(c, bg, a)
+    return math.floor(a * tonumber("0x"..c) + (1 - a) * tonumber("0x"..bg));
+end
+
+---@param hex string hex with 3 channels, ex: #00ff00
+---@param bg string hex with 3 channels, ex: #000000
+---@param a number between 0 and 1
+---@return string
+local add_alpha = function(hex, bg, a)
+    local r1, g1, b1 = hex:sub(2,3), hex:sub(4,5), hex:sub(6,7)
+    local r2, g2, b2 = bg:sub(2,3), bg:sub(4,5), bg:sub(6,7)
+    return "#"..string.format("%02x%02x%02x",
+        blend(r1, r2, a), blend(g1, g2, a), blend(b1, b2, a))
+end
+
 ---@param C table
 ---@param O table
 ---@return table
@@ -125,10 +144,10 @@ M.theme = function(C, O)
     diffFile = { fg = C.cyan },
     diffLine = { fg = C.bright_cyan },
     diffIndexLine = { fg = C.bright_black },
-    DiffAdd = { fg = C.green, bg = C.none, reverse = true }, -- diff mode: Added line |diff.txt|
-    DiffChange = { fg = C.yellow, bg = C.none, reverse = true }, -- diff mode: Changed line |diff.txt|
-    DiffDelete = { fg = C.red, bg = C.none, reverse = true }, -- diff mode: Deleted line |diff.txt|
-    DiffText = { bg = C.bright_black }, -- diff mode: Changed text within a changed line |diff.txt|
+    DiffAdd = { bg = add_alpha(C.green, C.background, 0.20)}, -- diff mode: Added line |diff.txt|
+    DiffChange = { bg = add_alpha(C.yellow, C.background, 0.20) }, -- diff mode: Changed line |diff.txt|
+    DiffDelete = { bg = add_alpha(C.bright_red, C.background, 0.20) }, -- diff mode: Deleted line |diff.txt|
+    DiffText = { bg = add_alpha(C.yellow, C.background, 0.35) }, -- diff mode: Changed text within a changed line |diff.txt|
 
     -- NeoVim
     healthError = { fg = C.red },


### PR DESCRIPTION
Hey there,

I have been using Citruszest as my main neovim theme for quite some time now, and I've really been enjoying it.
I recently included sindrets/diffview as part of my neovim config and thought that the diff view setup in Citruszest looked unfinished. 

### The change
I have added a function to blend colors allowing us to give hex colors a "hidden" alpha channel, and I have made some minor changes to how we define the different Diff colors.

Let me know what you think!


### Before changes
![image](https://github.com/zootedb0t/citruszest.nvim/assets/87569652/5588ead1-7f1d-4b29-8126-033e1d10e3ff)

### After changes
![diffview1](https://github.com/zootedb0t/citruszest.nvim/assets/87569652/11016791-1c05-41fa-b648-e14aaf4b7dbc)
![diffview2](https://github.com/zootedb0t/citruszest.nvim/assets/87569652/f4b5fbd5-04ff-47e8-8bf4-c566c192df66)
